### PR TITLE
docs(npm commands): Remove sudo and add --dev-dependencies flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Provides the `phantombuster` command to facilitate development of scripts for Ph
 
 To install:
 
-`sudo npm install -g phantombuster-sdk` (recommended)
+`npm install -g phantombuster-sdk` (recommended)
 
 or
 
-`npm install phantombuster-sdk`
+`npm install -D phantombuster-sdk`
 
 For now, the only feature provided is the uploading of scripts via Phantombuster's API.
 


### PR DESCRIPTION
Using sudo for an npm command can cause permissions issues and will not work on windows.
There are some articles such as [this one](https://medium.com/@ExplosionPills/dont-use-sudo-with-npm-still-66e609f5f92) with 722 claps explaining the different drawbacks of using sudo with npm commands, and the [npm official documentation](https://docs.npmjs.com/downloading-and-installing-packages-globally) doesn't use sudo as well, even for globally installed packages.

The -D flag for the local installation avoid bundling the sdk in the project when compiling it.