### PR TITLE
fix typo in package json keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "keywords": [
     "phantombuster",
-    "capserjs",
+    "casperjs",
     "phantomjs",
     "sdk",
     "headless",


### PR DESCRIPTION
Fix a typo in the package json keywords, which are use to reference the package