### PR TITLE
Use json needle option

### DIFF
--- a/lib/sdk.js
+++ b/lib/sdk.js
@@ -85,6 +85,7 @@ try {
                   mdText = '';
                 }
                 options = {
+                  json: true,
                   headers: {
                     'X-Phantombuster-Key-1': account.apiKey
                   }
@@ -137,6 +138,7 @@ try {
             return console.log("" + (datePrefix()) + account.name + ": " + localScript + ": " + (err.toString()));
           } else {
             options = {
+              json: true,
               headers: {
                 'X-Phantombuster-Key-1': account.apiKey
               }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "phantombuster-sdk",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantombuster-sdk",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Phantombuster's SDK",
   "main": "lib/sdk.js",
   "scripts": {

--- a/src/sdk.coffee
+++ b/src/sdk.coffee
@@ -60,6 +60,7 @@ try
 								if err
 									mdText = ''
 								options =
+									json: true
 									headers:
 										'X-Phantombuster-Key-1': account.apiKey
 								payload =
@@ -91,6 +92,7 @@ try
 						console.log "#{datePrefix()}#{account.name}: #{localScript}: #{err.toString()}"
 					else
 						options =
+							json: true
 							headers:
 								'X-Phantombuster-Key-1': account.apiKey
 						payload =


### PR DESCRIPTION
Add JSON option in needle calls, which will use different headers and encoding, allowing the SDK to send script with a size of 600k instead of ~370k.

Before with a script of 370k:
<img width="463" alt="image" src="https://user-images.githubusercontent.com/3717331/233407202-78c874e7-f861-4204-bd45-79fb913fc480.png">

After:
<img width="459" alt="image" src="https://user-images.githubusercontent.com/3717331/233407534-ecc6181e-904d-4473-aaf8-d62dfc755874.png">
