### PR TITLE
chore: improve prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/sdk.js",
   "scripts": {
     "test": "echo \"Error: no tests exist\" && exit 1",
-    "prepublish": "coffee --bare -o lib/ -c src/*.coffee && sed -i '1s/^/\\#\\!\\/usr\\/bin\\/env node\\n/' lib/sdk.js",
+    "prepare": "coffee --bare -o lib/ -c src/*.coffee && sed -i.bak '1s/^/\\#\\!\\/usr\\/bin\\/env node\\n/' lib/sdk.js && rm lib/sdk.js.bak",
     "watch": "coffee --bare -w -o lib/ -c src/*.coffee"
   },
   "repository": {


### PR DESCRIPTION
## 📝 What is this PR

prepublish is configusing because its name implies that it will be run before publishing, but [according to npm](https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish) it's actually run only after installing.
Also the sed command was made for linux but was not compatible with mac os because of the `-i` behavior.

## 🏭 How does it work

- Using `prepare` instead of `prepublish` to be sure that the script will be compiled before publishing it.
- updating the sed command with a crossplatform fix (https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux)

## 🗒 Notes

-   [ ] This change requires a documentation update
-   [ ] This change requires a unit tests update

## 🧪 QA Process

Run `npm i` on a mac and a linux and check that the `lib/sdk.js` file is prefixed with a node shebang.

## 👌 To check

-   [X] There's no regression
-   [X] Coding guidelines are followed ([Contributing](https://github.com/phantombuster/engineering-docs/blob/master/contributing.md), [Testing](https://github.com/phantombuster/engineering-docs/blob/master/testing.md))

## 🚀 What to do after deployment

Install the sdk locally with `npm -g` and check that the `lib/sdk.js` is correct.